### PR TITLE
feat: add aliases option

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Note that `NuxtIcon` needs to be inside `components/global/` folder (see [exampl
 
 To update the default size (`1em`) of the `<Icon />`, create an `app.config.ts` with the `nuxtIcon.size` property.
 
-You can also define aliases to make swapping out icons easier. Just provide a dict with `{ alias: iconName }` under the `nuxtIcon.aliases` property.
+You can also define aliases to make swapping out icons easier by leveraging the `nuxtIcon.aliases` property.
 
 ```ts
 // app.config.ts
@@ -83,10 +83,16 @@ export default defineAppConfig({
   nuxtIcon: {
     size: '24px', // default <Icon> size applied
     aliases: {
-      'nuxt-icon': 'logos:nuxt-icon',
+      'nuxt': 'logos:nuxt-icon',
     }
   }
 })
+```
+
+The icons will have the default size of `24px` and the `nuxt` icon will be available:
+
+```html
+<Icon name="nuxt" />
 ```
 
 ## Contributing 🙏

--- a/README.md
+++ b/README.md
@@ -73,13 +73,19 @@ Note that `NuxtIcon` needs to be inside `components/global/` folder (see [exampl
 
 ## Configuration ⚙️
 
-To update the default size (`1em`) of the `<Icon />`, create an `app.config.ts` with the `nuxtIcon.size` property:
+To update the default size (`1em`) of the `<Icon />`, create an `app.config.ts` with the `nuxtIcon.size` property.
+
+You can also define aliases to make swapping out icons easier. Just provide a dict with `{ alias: iconName }` under the `nuxtIcon.aliases` property.
 
 ```ts
 // app.config.ts
 export default defineAppConfig({
   nuxtIcon: {
     size: '24px' // default <Icon> size applied
+    aliases: {
+      'nuxt-icon': 'logos:nuxt-icon',
+      // ...
+    }
   }
 })
 ```

--- a/README.md
+++ b/README.md
@@ -81,10 +81,9 @@ You can also define aliases to make swapping out icons easier. Just provide a di
 // app.config.ts
 export default defineAppConfig({
   nuxtIcon: {
-    size: '24px' // default <Icon> size applied
+    size: '24px', // default <Icon> size applied
     aliases: {
       'nuxt-icon': 'logos:nuxt-icon',
-      // ...
     }
   }
 })

--- a/playground/app.config.ts
+++ b/playground/app.config.ts
@@ -1,5 +1,10 @@
 export default defineAppConfig({
   nuxtIcon: {
-    size: '1em'
+    size: '1em',
+    aliases: {
+      'awesome-github': 'carbon:logo-github',
+      'awesome-nuxt': 'logos:nuxt-icon',
+      'awesome-rocket': 'fluent-emoji:rocket'
+    }
   }
 })

--- a/playground/app.config.ts
+++ b/playground/app.config.ts
@@ -2,9 +2,9 @@ export default defineAppConfig({
   nuxtIcon: {
     size: '1em',
     aliases: {
-      'awesome-github': 'carbon:logo-github',
-      'awesome-nuxt': 'logos:nuxt-icon',
-      'awesome-rocket': 'fluent-emoji:rocket'
+      github: 'carbon:logo-github',
+      nuxt: 'logos:nuxt-icon',
+      rocket: 'fluent-emoji:rocket'
     }
   }
 })

--- a/playground/app.vue
+++ b/playground/app.vue
@@ -20,9 +20,9 @@
     </p>
     <p>
       Aliases:
-      <Icon name="awesome-github" />
-      <Icon name="awesome-nuxt" />
-      <Icon name="awesome-rocket" />
+      <Icon name="github" size="24" />
+      <Icon name="nuxt" size="24" />
+      <Icon name="rocket" size="24" />
     </p>
   </div>
 </template>

--- a/playground/app.vue
+++ b/playground/app.vue
@@ -18,6 +18,12 @@
       <Icon name="🚀" size="24" />
       <Icon name="🚀" size="48" />
     </p>
+    <p>
+      Aliases:
+      <Icon name="awesome-github" />
+      <Icon name="awesome-nuxt" />
+      <Icon name="awesome-rocket" />
+    </p>
   </div>
 </template>
 

--- a/src/module.ts
+++ b/src/module.ts
@@ -7,7 +7,8 @@ declare module '@nuxt/schema' {
     /** nuxt-icon configuration */
     nuxtIcon?: {
       /** default size */
-      size?: string
+      size?: string,
+      aliases?: { [alias: string]: string }
     }
   }
 }

--- a/src/runtime/Icon.vue
+++ b/src/runtime/Icon.vue
@@ -19,8 +19,9 @@ const props = defineProps({
 })
 const state = useState<Record<string, IconifyIcon | undefined>>('icons', () => ({}))
 const isFetching = ref(false)
-const icon = computed<IconifyIcon | undefined>(() => state.value?.[props.name])
-const component = computed(() => nuxtApp.vueApp.component(props.name))
+const iconName = computed(() => (nuxtIcon?.aliases || {})[props.name] || props.name)
+const icon = computed<IconifyIcon | undefined>(() => state.value?.[iconName.value])
+const component = computed(() => nuxtApp.vueApp.component(iconName.value))
 const sSize = computed(() => {
   const size = props.size || nuxtIcon?.size || '1em'
   if (String(Number(size)) === size) {
@@ -33,14 +34,14 @@ async function loadIconComponent () {
   if (component.value) {
     return
   }
-  if (!state.value?.[props.name]) {
+  if (!state.value?.[iconName.value]) {
     isFetching.value = true
-    state.value[props.name] = await loadIcon(props.name).catch(() => undefined)
+    state.value[iconName.value] = await loadIcon(iconName.value).catch(() => undefined)
     isFetching.value = false
   }
 }
 
-watch(() => props.name, loadIconComponent)
+watch(() => iconName.value, loadIconComponent)
 
 !component.value && await loadIconComponent()
 </script>


### PR DESCRIPTION
Replacing icons in big projects can be tedious and it's sometimes hard to remember which exact icon was used for a certain element. With the `aliases` option you can define your own names for icons and easily swap them out in your entire application.