### PR TITLE
feat: Add headless option to nuxtIcon config

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Note that `NuxtIcon` needs to be inside `components/global/` folder (see [exampl
 
 To update the default size (`1em`) of the `<Icon />`, create an `app.config.ts` with the `nuxtIcon.size` property.
 
-Update the default class (`.icon`) of the `<Icon />` with the `nuxtIcon.class` property.
+Update the default class (`.icon`) of the `<Icon />` with the `nuxtIcon.class` property, for a headless Icon, simply set `nuxtIcon.class: ''`.
 
 You can also define aliases to make swapping out icons easier by leveraging the `nuxtIcon.aliases` property.
 

--- a/src/module.ts
+++ b/src/module.ts
@@ -8,7 +8,8 @@ declare module '@nuxt/schema' {
     nuxtIcon?: {
       /** default size */
       size?: string,
-      aliases?: { [alias: string]: string }
+      aliases?: { [alias: string]: string },
+      headless?: boolean
     }
   }
 }

--- a/src/module.ts
+++ b/src/module.ts
@@ -7,7 +7,6 @@ declare module '@nuxt/schema' {
     /** nuxt-icon configuration */
     nuxtIcon?: {
       size?: string,
-      headless?: boolean
       class?: string,
       aliases?: { [alias: string]: string }
     }
@@ -23,7 +22,7 @@ export default defineNuxtModule<ModuleOptions>({
     }
   },
   defaults: {},
-  setup (_options, nuxt) {
+  setup (_options) {
     const { resolve } = createResolver(import.meta.url)
 
     addComponent({

--- a/src/runtime/Icon.vue
+++ b/src/runtime/Icon.vue
@@ -30,10 +30,7 @@ const sSize = computed(() => {
   return size
 })
 
-const isHeadless = computed(() => {
-  return nuxtIcon?.headless || false
-})
-
+const isHeadless = nuxtIcon?.headless ?? false
 async function loadIconComponent () {
   if (component.value) {
     return

--- a/src/runtime/Icon.vue
+++ b/src/runtime/Icon.vue
@@ -29,9 +29,8 @@ const sSize = computed(() => {
   }
   return size
 })
-const className = nuxtIcon?.headless ? '' : (nuxtIcon?.class ?? 'icon')
+const className = computed(() => nuxtIcon?.class ?? 'icon')
 
-const isHeadless = nuxtIcon?.headless ?? false
 async function loadIconComponent () {
   if (component.value) {
     return

--- a/src/runtime/Icon.vue
+++ b/src/runtime/Icon.vue
@@ -30,6 +30,10 @@ const sSize = computed(() => {
   return size
 })
 
+const isHeadless = computed(() => {
+  return nuxtIcon?.headless || false
+})
+
 async function loadIconComponent () {
   if (component.value) {
     return
@@ -48,7 +52,7 @@ watch(() => iconName.value, loadIconComponent)
 
 <template>
   <span v-if="isFetching" class="icon" :width="sSize" :height="sSize" />
-  <Iconify v-else-if="icon" :icon="icon" class="icon" :width="sSize" :height="sSize" />
+  <Iconify v-else-if="icon" :icon="icon" :class="{ icon: isHeadless }" :width="sSize" :height="sSize" />
   <Component :is="component" v-else-if="component" class="icon" :width="sSize" :height="sSize" />
   <span v-else class="icon" :style="{ fontSize: sSize, lineHeight: sSize, width: sSize, height: sSize }">{{ name }}</span>
 </template>

--- a/src/runtime/Icon.vue
+++ b/src/runtime/Icon.vue
@@ -51,10 +51,10 @@ watch(() => iconName.value, loadIconComponent)
 </script>
 
 <template>
-  <span v-if="isFetching" class="icon" :width="sSize" :height="sSize" />
+  <span v-if="isFetching" :class="{ icon: isHeadless }" :width="sSize" :height="sSize" />
   <Iconify v-else-if="icon" :icon="icon" :class="{ icon: isHeadless }" :width="sSize" :height="sSize" />
-  <Component :is="component" v-else-if="component" class="icon" :width="sSize" :height="sSize" />
-  <span v-else class="icon" :style="{ fontSize: sSize, lineHeight: sSize, width: sSize, height: sSize }">{{ name }}</span>
+  <Component :is="component" v-else-if="component" :class="{ icon: isHeadless }" :width="sSize" :height="sSize" />
+  <span v-else :class="{ icon: isHeadless }" :style="{ fontSize: sSize, lineHeight: sSize, width: sSize, height: sSize }">{{ name }}</span>
 </template>
 
 <style scoped>


### PR DESCRIPTION
Adds a headless option to remove `.icon` class from the icon component.

Resolves #24 