### PR TITLE
Feature: Add `class` option to `nuxtIcon` config

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ Note that `NuxtIcon` needs to be inside `components/global/` folder (see [exampl
 
 To update the default size (`1em`) of the `<Icon />`, create an `app.config.ts` with the `nuxtIcon.size` property.
 
+Update the default class (`.icon`) of the `<Icon />` with the `nuxtIcon.class` property.
+
 You can also define aliases to make swapping out icons easier by leveraging the `nuxtIcon.aliases` property.
 
 ```ts
@@ -83,6 +85,7 @@ You can also define aliases to make swapping out icons easier by leveraging the 
 export default defineAppConfig({
   nuxtIcon: {
     size: '24px', // default <Icon> size applied
+    class: 'icon', // default <Icon> class applied
     aliases: {
       'nuxt': 'logos:nuxt-icon',
     }

--- a/src/module.ts
+++ b/src/module.ts
@@ -8,6 +8,7 @@ declare module '@nuxt/schema' {
     nuxtIcon?: {
       /** default size */
       size?: string,
+      class?: string,
       aliases?: { [alias: string]: string }
     }
   }

--- a/src/runtime/Icon.vue
+++ b/src/runtime/Icon.vue
@@ -29,6 +29,7 @@ const sSize = computed(() => {
   }
   return size
 })
+const className = nuxtIcon?.class ?? 'icon'
 
 async function loadIconComponent () {
   if (component.value) {
@@ -47,10 +48,10 @@ watch(() => iconName.value, loadIconComponent)
 </script>
 
 <template>
-  <span v-if="isFetching" class="icon" :width="sSize" :height="sSize" />
-  <Iconify v-else-if="icon" :icon="icon" class="icon" :width="sSize" :height="sSize" />
-  <Component :is="component" v-else-if="component" class="icon" :width="sSize" :height="sSize" />
-  <span v-else class="icon" :style="{ fontSize: sSize, lineHeight: sSize, width: sSize, height: sSize }">{{ name }}</span>
+  <span v-if="isFetching" :class="className" :width="sSize" :height="sSize" />
+  <Iconify v-else-if="icon" :icon="icon" :class="className" :width="sSize" :height="sSize" />
+  <Component :is="component" v-else-if="component" :class="className" :width="sSize" :height="sSize" />
+  <span v-else :class="className" :style="{ fontSize: sSize, lineHeight: sSize, width: sSize, height: sSize }">{{ name }}</span>
 </template>
 
 <style scoped>


### PR DESCRIPTION
Adds an option to change the default class of the `<Icon />` component or remove it entirely.

To remove the class entirely:
```ts
// app.config.ts
export default defineAppConfig({
  nuxtIcon: {
    class: '', // default .icon class is removed
})
```

Resolves #24 