### PR TITLE
feat: autocomplete aliases

### DIFF
--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -1,7 +1,7 @@
 import nuxtIcon from '../src/module'
 
 export default defineNuxtConfig({
-  typescript: { strict: true },
+  typescript: { strict: true, includeWorkspace: true },
   modules: [
     nuxtIcon
   ]

--- a/src/runtime/Icon.vue
+++ b/src/runtime/Icon.vue
@@ -1,15 +1,17 @@
 <!-- eslint-disable vue/multi-word-component-names -->
 <script setup lang="ts">
+import type { PropType } from 'vue'
 import type { IconifyIcon } from '@iconify/vue'
 import { Icon as Iconify } from '@iconify/vue/dist/offline'
 import { loadIcon } from '@iconify/vue'
 import { useNuxtApp, useState, ref, useAppConfig, computed, watch } from '#imports'
+import type { AppConfig } from '@nuxt/schema'
 
 const nuxtApp = useNuxtApp()
 const appConfig = useAppConfig() as any
 const props = defineProps({
   name: {
-    type: String,
+    type: String as PropType<keyof AppConfig['nuxtIcon']['aliases'] | (string & {})>,
     required: true
   },
   size: {


### PR DESCRIPTION
<img width="747" alt="CleanShot 2023-01-25 at 14 36 41@2x" src="https://user-images.githubusercontent.com/1385263/214577851-4da9419b-00ed-49c6-9a5d-8bd90600b0c9.png">

This PR adds autocomplete on aliases on the `name` prop of `Icon.vue`.

It keeps the type permissive as any other string can be a name, but provides suggestions over the known aliases of the `appConfig.nuxtIcon.aliases` key.