### PR TITLE
Import ref, computed & watch from vue instead of #imports

### DIFF
--- a/src/runtime/Icon.vue
+++ b/src/runtime/Icon.vue
@@ -4,7 +4,8 @@ import type { PropType } from 'vue'
 import type { IconifyIcon } from '@iconify/vue'
 import { Icon as Iconify } from '@iconify/vue/dist/offline'
 import { loadIcon } from '@iconify/vue'
-import { useNuxtApp, useState, ref, useAppConfig, computed, watch } from '#imports'
+import { ref, computed, watch } from 'vue'
+import { useAppConfig, useNuxtApp, useState } from '#imports'
 
 const nuxtApp = useNuxtApp()
 const appConfig = useAppConfig()

--- a/src/runtime/IconCSS.vue
+++ b/src/runtime/IconCSS.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import type { PropType } from 'vue'
-import { useAppConfig, computed } from '#imports'
+import { computed } from 'vue'
+import { useAppConfig } from '#imports'
 
 const appConfig = useAppConfig()
 const aliases = appConfig?.nuxtIcon?.aliases || {}


### PR DESCRIPTION
Changing the Imports for `ref` `computed` and `watch` to be imported from vue directly instead of `#imports` reason for this change is, that for me, webstorm fails to detect the type of a ref when used with nuxt3's auto import.

I manually disabled the implicit imports for `vue` sadly this has the side effect, that they no longer are available from `#imports` causing this to break, importing them direcly from vue fixes this issue :)

Would apreciate it alot if this gets merged :D