### PR TITLE
Add color prop to README.md documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ That's it, you can now use the `<Icon />` in your components!
 **Props:**
 - `name` (required): icon name, emoji or global component name
 - `size`: icon size (default: `1em`)
+- `color`: svg path color
 
 ### Iconify dataset
 


### PR DESCRIPTION
I had to dig around to found out how the change the color of the icons, with this issue solving my query, https://github.com/nuxt-modules/icon/issues/17.

I edited the documentation so it is clearer for future users.