### PR TITLE
fix(Icon.vue): fix size of element being fetched

### DIFF
--- a/src/runtime/Icon.vue
+++ b/src/runtime/Icon.vue
@@ -61,7 +61,7 @@ watch(() => iconName.value, loadIconComponent)
 </script>
 
 <template>
-  <span v-if="isFetching" :class="className" :width="sSize" :height="sSize" />
+  <span v-if="isFetching" :class="className" :style="{ width: sSize, height: sSize }" />
   <Iconify v-else-if="icon" :icon="icon" :class="className" :width="sSize" :height="sSize" />
   <Component :is="component" v-else-if="component" :class="className" :width="sSize" :height="sSize" />
   <span v-else :class="className" :style="{ fontSize: sSize, lineHeight: sSize, width: sSize, height: sSize }"><slot>{{ name }}</slot></span>


### PR DESCRIPTION
This loses the size of my icon, causing the layout to shift, so fix it

![image](https://github.com/nuxt-modules/icon/assets/57781857/3f9812b6-d3ff-466a-9e1c-466d719eb793)
