### PR TITLE
fix: add type for unknown appConfig

### DIFF
--- a/src/runtime/Icon.vue
+++ b/src/runtime/Icon.vue
@@ -7,7 +7,13 @@ import { ref, computed, watch } from 'vue'
 import { useAppConfig, useNuxtApp, useState } from '#imports'
 
 const nuxtApp = useNuxtApp()
-const appConfig = useAppConfig()
+const appConfig = useAppConfig() as {
+  nuxtIcon: {
+    size?: string
+    class?: string
+    aliases?: Record<string, string>
+  }
+}
 
 const props = defineProps({
   name: {
@@ -22,7 +28,13 @@ const props = defineProps({
 
 const state = useState<Record<string, IconifyIcon | undefined>>('icons', () => ({}))
 const isFetching = ref(false)
-const iconName = computed(() => ((appConfig.nuxtIcon?.aliases || {})[props.name] || props.name).replace(/^i-/, ''))
+const iconName = computed(() => {
+  if (appConfig.nuxtIcon.aliases && appConfig.nuxtIcon.aliases[props.name]) {
+    return appConfig.nuxtIcon.aliases[props.name].replace(/^i-/, '')
+  }
+
+  return props.name.replace(/^i-/, '')
+})
 const icon = computed<IconifyIcon | undefined>(() => state.value?.[iconName.value])
 const component = computed(() => nuxtApp.vueApp.component(iconName.value as string))
 const sSize = computed(() => {

--- a/src/runtime/IconCSS.vue
+++ b/src/runtime/IconCSS.vue
@@ -2,7 +2,13 @@
 import { computed } from 'vue'
 import { useAppConfig } from '#imports'
 
-const appConfig = useAppConfig()
+const appConfig = useAppConfig() as {
+  nuxtIcon: {
+    size?: string
+    class?: string
+    aliases?: Record<string, string>
+  }
+}
 
 const props = defineProps({
   name: {
@@ -15,7 +21,13 @@ const props = defineProps({
   }
 })
 
-const iconName = computed(() => ((appConfig.nuxtIcon?.aliases || {})[props.name] || props.name).replace(/^i-/, ''))
+const iconName = computed(() => {
+  if (appConfig.nuxtIcon.aliases && appConfig.nuxtIcon.aliases[props.name]) {
+    return appConfig.nuxtIcon.aliases[props.name].replace(/^i-/, '')
+  }
+
+  return props.name.replace(/^i-/, '')
+})
 const iconUrl = computed(() => `url('https://api.iconify.design/${iconName.value.replace(':', '/')}.svg')`)
 const sSize = computed(() => {
   // Disable size if appConfig.nuxtIcon.size === false


### PR DESCRIPTION
fix #103 

* The appConfig type from useAppConfig uses a unknown type as value, this PR set the value for the returned appConfig
``` ts
interface AppConfig {
    [key: string]: unknown;
}
```
* Simplify `iconName` computed logic

|Before|After|
|-------|-----|
|![image](https://github.com/nuxt-modules/icon/assets/38621036/b9e27bad-2f6a-4223-9498-83e387ecb5d8)|![image](https://github.com/nuxt-modules/icon/assets/38621036/66150fc5-1f08-44ad-8dfc-364652bdc7ab)|