### PR TITLE
fix: support undefined app.config `nuxtIcon`

### DIFF
--- a/src/runtime/Icon.vue
+++ b/src/runtime/Icon.vue
@@ -59,7 +59,7 @@ watch(() => appConfig.nuxtIcon?.iconifyApiOptions, () => {
 const state = useState<Record<string, IconifyIcon | undefined>>('icons', () => ({}))
 const isFetching = ref(false)
 const iconName = computed(() => {
-  if (appConfig.nuxtIcon.aliases && appConfig.nuxtIcon.aliases[props.name]) {
+  if (appConfig.nuxtIcon?.aliases && appConfig.nuxtIcon.aliases[props.name]) {
     return appConfig.nuxtIcon.aliases[props.name].replace(/^i-/, '')
   }
 

--- a/src/runtime/Icon.vue
+++ b/src/runtime/Icon.vue
@@ -59,7 +59,7 @@ watch(() => appConfig.nuxtIcon?.iconifyApiOptions, () => {
 const state = useState<Record<string, IconifyIcon | undefined>>('icons', () => ({}))
 const isFetching = ref(false)
 const iconName = computed(() => {
-  if (appConfig.nuxtIcon?.aliases && appConfig.nuxtIcon.aliases[props.name]) {
+  if (appConfig.nuxtIcon?.aliases?.[props.name]) {
     return appConfig.nuxtIcon.aliases[props.name].replace(/^i-/, '')
   }
 


### PR DESCRIPTION
Resolves #100 

### Problem

While accessing properties of `nuxtIcon`, the application would throw a `TypeError` if `nuxtIcon` was undefined.

### Solution

Added optional chaining (`?.`) to safely access the nested properties of `nuxtIcon`.

### Changes

- Implemented optional chaining to check the existence of `nuxtIcon` before trying to access its `aliases` property.
- This resolves the error: "TypeError: Cannot read properties of undefined (reading 'aliases')".