### PR TITLE
fix: add non-null assertion to iconName

### DIFF
--- a/src/runtime/Icon.vue
+++ b/src/runtime/Icon.vue
@@ -61,7 +61,7 @@ const state = useState<Record<string, IconifyIcon | undefined>>('icons', () => (
 const isFetching = ref(false)
 const iconName = computed(() => {
   if (appConfig.nuxtIcon?.aliases?.[props.name]) {
-    return appConfig.nuxtIcon.aliases[props.name]
+    return appConfig.nuxtIcon.aliases[props.name]!
   }
   return props.name
 })


### PR DESCRIPTION
fix #132

Added non-null assertion in `iconName` so that TypeScript can infer the type as `string`, not `string | undefined`.