### PR TITLE
fix(icon): use optional chaining to fix 'undefined' error in Histoire

### DIFF
--- a/src/runtime/Icon.vue
+++ b/src/runtime/Icon.vue
@@ -68,7 +68,7 @@ const iconName = computed(() => {
 const resolvedIcon = computed(() => resolveIconName(iconName.value))
 const iconKey = computed(() => [resolvedIcon.value.provider, resolvedIcon.value.prefix, resolvedIcon.value.name].filter(Boolean).join(':'))
 const icon = computed<IconifyIcon | undefined>(() => state.value?.[iconKey.value])
-const component = computed(() => nuxtApp.vueApp.component(iconName.value))
+const component = computed(() => nuxtApp.vueApp?.component(iconName.value))
 const sSize = computed(() => {
   // Disable size if appConfig.nuxtIcon.size === false
   // @ts-ignore


### PR DESCRIPTION
### Problem

When using the NuxtIcon (Icon) component in Histoire stories, an error occurs:
`Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'component')
    at Icon.vue:71:49` 
![obraz](https://github.com/nuxt-modules/icon/assets/29805551/322ce740-6d5f-4f23-99ed-b65f9b10f110)


### Solution
Added optional chaining (?.) to component computed:
` ...nuxtApp.vueApp?.component...`

### Changes

- Implemented optional chaining to check the existence of vueApp in nuxtApp before trying to access.
- This resolves the error: "TypeError: Cannot read properties of undefined (reading 'component')".

### Test
clone: https://github.com/RobertHaba/icon/tree/feature/histoire-example
or add Histoire package

**package.json**
```
"devDependencies": {
    "@histoire/plugin-nuxt": "^0.17.14",
    "@histoire/plugin-vue": "^0.17.14",
    "histoire": "^0.17.14",
    ...
  }
  ```
  
**histoire.config.ts**
```
import { defineConfig } from "histoire"
import { HstVue } from "@histoire/plugin-vue"
import { HstNuxt } from "@histoire/plugin-nuxt"
export default defineConfig({
  plugins: [
    HstVue()
    HstNuxt()
  ]
})
```

**Icon.story.vue**
```
<template>
  <Story>
    <Icon name="uil:github" />
  </Story>
</template>
```

![obraz](https://github.com/nuxt-modules/icon/assets/29805551/0f42de36-bbb2-4e24-beab-d046f7020067)

