### PR TITLE
feat: support custom collections from layers

### DIFF
--- a/playground/app.vue
+++ b/playground/app.vue
@@ -161,6 +161,14 @@ function clear() {
           :mode
         />
       </p>
+      <p>
+        Custom icons from layer:
+        <Icon
+          name="layer:layer"
+          size="64"
+          :mode
+        />
+      </p>
       <!-- <p>
         Emoji:
         <Icon name="🚀" />

--- a/playground/base/icons/layer.svg
+++ b/playground/base/icons/layer.svg
@@ -1,0 +1,2 @@
+<!-- lucide:layers -->
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24"><g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"><path d="M12.83 2.18a2 2 0 0 0-1.66 0L2.6 6.08a1 1 0 0 0 0 1.83l8.58 3.91a2 2 0 0 0 1.66 0l8.58-3.9a1 1 0 0 0 0-1.83Z"/><path d="m6.08 9.5l-3.5 1.6a1 1 0 0 0 0 1.81l8.6 3.91a2 2 0 0 0 1.65 0l8.58-3.9a1 1 0 0 0 0-1.83l-3.5-1.59"/><path d="m6.08 14.5l-3.5 1.6a1 1 0 0 0 0 1.81l8.6 3.91a2 2 0 0 0 1.65 0l8.58-3.9a1 1 0 0 0 0-1.83l-3.5-1.59"/></g></svg>

--- a/playground/base/nuxt.config.ts
+++ b/playground/base/nuxt.config.ts
@@ -1,0 +1,22 @@
+import { createResolver } from '@nuxt/kit'
+
+const { resolve } = createResolver(import.meta.url)
+
+export default defineNuxtConfig({
+  app: {
+    head: {
+      title: 'Nuxt Layer Icon Playground',
+      meta: [
+        { name: 'description', content: 'The <Icon> component, supporting Iconify, Emojis and custom components.' },
+      ],
+    },
+  },
+  icon: {
+    customCollections: [
+      {
+        prefix: 'layer',
+        dir: resolve('./icons'),
+      },
+    ],
+  },
+})

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -3,6 +3,9 @@ export default defineNuxtConfig({
     '../src/module',
     '@unocss/nuxt',
   ],
+  extends: [
+    './base',
+  ],
   // ssr: false,
   icon: {
     customCollections: [

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,4 +1,4 @@
-import { basename, join } from 'node:path'
+import { basename, join, isAbsolute } from 'node:path'
 import fs from 'node:fs/promises'
 import { defineNuxtModule, addPlugin, addServerHandler, hasNuxtModule, createResolver, addTemplate, addComponent, logger } from '@nuxt/kit'
 import { addCustomTab } from '@nuxt/devtools-kit'
@@ -198,7 +198,7 @@ async function resolveCollection(nuxt: Nuxt, collection: string | IconifyJSON | 
     return collection
   // Custom collection
   if ('dir' in collection) {
-    const dir = join(nuxt.options.rootDir, collection.dir)
+    const dir = isAbsolute(collection.dir) ? collection.dir : join(nuxt.options.rootDir, collection.dir)
     const files = (await fg('*.svg', { cwd: dir, onlyFiles: true }))
       .sort()
 


### PR DESCRIPTION
Hello, 
firstly, thank you for this package! I like the new approach of the v1.

Here's a PR to support `customCollections` from layers
It's common to use in layers `const { resolve } = createResolver(import.meta.url)`,
but currently, all `customCollections.dir` paths were prefixed with `nuxt.options.rootDir`

This PR just adds an `isAbsolute` check, and adds a `base` layer in the playground for test purpose